### PR TITLE
Fix stylization of "Firefox"

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -32,12 +32,12 @@ layout: layout
           <code>X-Webkit-CSP</code> <span class="label label-warning">Deprecated</span> - Chrome 14-24
         </div>
 
-        <h3><i class="fa fa-firefox"></i> FireFox</h3>
+        <h3><i class="fa fa-firefox"></i> Firefox</h3>
         <div class="pd">
           <code>Content-Security-Policy</code> <span class="label label-success">CSP Level 3</span> - Firefox 58+ <small>Partial Support</small><br>
-          <code>Content-Security-Policy</code> <span class="label label-success">CSP Level 2</span> - FireFox 31+ <small title="45+ is missing the plugin-types directive"><em>Partial Support</em> since July 2014</small><br>
-          <code>Content-Security-Policy</code> <span class="label label-success">CSP 1.0</span> - FireFox 23+ <small>Full Support</small><br>
-          <code>X-Content-Security-Policy</code> <span class="label label-warning">Deprecated</span> - FireFox 4-22
+          <code>Content-Security-Policy</code> <span class="label label-success">CSP Level 2</span> - Firefox 31+ <small title="45+ is missing the plugin-types directive"><em>Partial Support</em> since July 2014</small><br>
+          <code>Content-Security-Policy</code> <span class="label label-success">CSP 1.0</span> - Firefox 23+ <small>Full Support</small><br>
+          <code>X-Content-Security-Policy</code> <span class="label label-warning">Deprecated</span> - Firefox 4-22
         </div>
 
         <h3><i class="fa fa-safari"></i> Safari</h3>


### PR DESCRIPTION
Mozilla only use one capital F in "Firefox". (Source: https://www.mozilla.org/en-US/)