### PR TITLE
Replace invalid nonce "r@nd0m" with "rAnd0m"

### DIFF
--- a/www/examples/allow-inline-script.html
+++ b/www/examples/allow-inline-script.html
@@ -32,11 +32,11 @@ tags: examples
 
 <p>One of the easiest ways to allow inline scripts when using CSP is to use a <a href="/nonce/" title="CSP Nonce">nonce</a>. A <a href="/nonce/" title="CSP Nonce">nonce</a> is just a random, single use string value that you add to your <code>Content-Security-Policy</code> header, like so:
 <pre>
-script-src js-cdn.example.com 'nonce-r@nd0m';
+script-src js-cdn.example.com 'nonce-rAnd0m';
 </pre>
-<p>Assuming our nonce value is <code>r@nd0m</code> (you need to randomly generate a new nonce for every HTTP request), we can now use an inline script tag like this:</p>
+<p>Assuming our nonce value is <code>rAnd0m</code> (you need to randomly generate a new nonce for every HTTP request), we can now use an inline script tag like this:</p>
 <pre>
-&lt;script nonce="r@nd0m"&gt;
+&lt;script nonce="rAnd0m"&gt;
 	doSomething();
 &lt;/script&gt;
 </pre>

--- a/www/examples/allow-inline-style.html
+++ b/www/examples/allow-inline-style.html
@@ -41,11 +41,11 @@ tags: examples
 
 <p>One of the easiest ways to allow style tags when using CSP is to use a <a href="/nonce/" title="CSP Nonce">nonce</a>. A <a href="/nonce/" title="CSP Nonce">nonce</a> is just a random, single use string value that you add to your <code>Content-Security-Policy</code> header, like so:
 <pre>
-style-src css-cdn.example.com 'nonce-r@nd0m';
+style-src css-cdn.example.com 'nonce-rAnd0m';
 </pre>
-<p>Assuming our nonce value is <code>r@nd0m</code> (you need to randomly generate a new nonce for every HTTP request), we can now use an inline style tag like this:</p>
+<p>Assuming our nonce value is <code>rAnd0m</code> (you need to randomly generate a new nonce for every HTTP request), we can now use an inline style tag like this:</p>
 <pre>
-&lt;style nonce="r@nd0m"&gt;
+&lt;style nonce="rAnd0m"&gt;
 	.red { color: red }
 &lt;/style&gt;
 </pre>
@@ -72,6 +72,3 @@ style-src 'self' 'unsafe-hashes' 'sha256-nMxMqdZhkHxz5vAuW/PAoLvECzzsmeAxD/BNwG1
 <h2>Other methods</h2>
 <p>The <a href="/unsafe-inline/"><code>unsafe-inline</code></a> source list keyword can be used to allow inline styles, but this also removes much of the security protection that you gain when you enable CSP.</p>
 <p>CSP Level 3 (newest browsers) support a source list value: <a href="/unsafe-hashes/"><code>unsafe-hashes</code></a> which can be used to allow inline style attributes on HTML tags.</p>
-
-
-

--- a/www/index.html
+++ b/www/index.html
@@ -62,13 +62,13 @@ layout: layout
 
         <br>
 
-        
+
         <p>Try our <a href="browser-test/">CSP Browser Test</a> to test your browser.</p>
         <p>Note: It is known that having both <code>Content-Security-Policy</code> and <code>X-Content-Security-Policy</code> or <code>X-Webkit-CSP</code> causes unexpected behaviours on certain versions of browsers. Please avoid using deprecated <code>X-*</code> headers.</p>
       </div>
 
 
-      
+
       <h2 id="directive">CSP Directive Reference</h2>
       <p>The <code>Content-Security-Policy</code> header value is made up of one or more directives (defined below), multiple directives are separated with a semicolon <code>;</code></p>
       <p>This documentation is provided based on the Content Security Policy Level 2 <a href="https://www.w3.org/TR/CSP2/">W3C Recommendation</a>, and the CSP Level 3 <a href="https://www.w3.org/TR/CSP3/">W3C Working Draft</a></p>
@@ -168,7 +168,7 @@ layout: layout
         <span class="label label-default" title="Firefox 23+ - August 2013"><i class="fa fa-firefox"></i> 23+</span>
         <span class="label label-default" title="Safari 7+ - October 2013"><i class="fa fa-safari"></i> 7+</span>
         <span class="label label-default" title="IE Edge 12.10240+ - July 2015"><i class="fa fa-edge"></i> 12+</span>
-      </div> 
+      </div>
 
       <h3><code>frame-src</code></h3>
       <div class="pd">
@@ -234,7 +234,7 @@ layout: layout
         <span class="label label-default" title="Chrome 39+ - November 2014"><i class="fa fa-chrome"></i> 39+</span>
         <span class="label label-default" title="Firefox 33+ - October 2014"><i class="fa fa-firefox"></i> 33+</span>
         <span class="label label-default" title="Edge 15+ - January 2017"><i class="fa fa-edge"></i> 15+</span>
-      </div>  
+      </div>
 
       <h3><code>plugin-types</code></h3>
       <div class="pd">
@@ -260,7 +260,7 @@ layout: layout
         <p>Defines a <em>reporting group</em> name defined by a <code>Report-To</code> HTTP response header. See the <a href="https://w3c.github.io/reporting/">Reporting API</a> for more info.</p>
         <h5>Example report-to Directive</h5>
         <pre>report-to groupName;</pre>
-        <span class="label label-success">CSP Level 3</span> 
+        <span class="label label-success">CSP Level 3</span>
         <span class="label label-default" title="Chrome 70+ - October 2018"><i class="fa fa-chrome"></i> 70+</span>
       </div>
 
@@ -269,7 +269,7 @@ layout: layout
         <p>Restricts the URLs which may be loaded as a Worker, SharedWorker or ServiceWorker.</p>
         <h5>Example worker-src Policy</h5>
         <pre>worker-src 'none';</pre>
-        <span class="label label-success">CSP Level 3</span> 
+        <span class="label label-success">CSP Level 3</span>
         <span class="label label-default" title="Chrome 59+ - June 2017"><i class="fa fa-chrome"></i> 59+</span>
         <span class="label label-default" title="Firefox 58+ - September 2017"><i class="fa fa-firefox"></i> 58+</span>
       </div>
@@ -279,7 +279,7 @@ layout: layout
         <p>Restricts the URLs that application manifests can be loaded.</p>
         <h5>Example manifest-src Policy</h5>
         <pre>manifest-src 'none';</pre>
-        <span class="label label-success">CSP Level 3</span> 
+        <span class="label label-success">CSP Level 3</span>
         <span class="label label-default" title="Chrome Supported"><i class="fa fa-chrome"></i> Yes</span>
         <span class="label label-default" title="Firefox 40+ - 2015"><i class="fa fa-firefox"></i> 40+</span>
       </div>
@@ -289,7 +289,7 @@ layout: layout
         <p>Defines valid sources for request prefetch and prerendering, for example via the <code>link</code> tag with <code>rel="prefetch"</code> or <code>rel="prerender"</code>:</p>
         <h5>Example prefetch-src Policy</h5>
         <pre>prefetch-src 'none'</pre>
-        <span class="label label-success">CSP Level 3</span> 
+        <span class="label label-success">CSP Level 3</span>
       </div>
 
       <h3><code>navigate-to</code></h3>
@@ -297,7 +297,7 @@ layout: layout
         <p>Restricts the URLs that the document may navigate to by any means. For example when a link is clicked, a form is submitted, or <code>window.location</code> is invoked. If <code>form-action</code> is present then this directive is ignored for form submissions. <a href="https://www.chromestatus.com/features/6457580339593216" rel="nofollow">Implementation Status</a></p>
         <h5>Example navigate-to Policy</h5>
         <pre>navigate-to example.com</pre>
-        <span class="label label-success">CSP Level 3</span> 
+        <span class="label label-success">CSP Level 3</span>
       </div>
 
 
@@ -372,8 +372,8 @@ layout: layout
           </tr>
           <tr>
             <td><a href="/nonce/" title="Nonce Support in CSP"><code>'nonce-'</code></a></td>
-            <td><code>script-src 'nonce-r@nd0m'</code></td>
-            <td>Allows an inline script or CSS to execute if the script (eg: <code>&lt;script nonce="r@nd0m"&gt;</code>) tag contains a nonce attribute matching the nonce specifed in the CSP header. The nonce should be a secure random string, and should not be reused. <span class="label label-success">CSP Level 2</span> </td>
+            <td><code>script-src 'nonce-rAnd0m'</code></td>
+            <td>Allows an inline script or CSS to execute if the script (eg: <code>&lt;script nonce="rAnd0m"&gt;</code>) tag contains a nonce attribute matching the nonce specifed in the CSP header. The nonce should be a secure random string, and should not be reused. <span class="label label-success">CSP Level 2</span> </td>
           </tr>
           <tr>
             <td><a href="/strict-dynamic/" title="CSP strict-dynamic"><code>'strict-dynamic'</code></a></td>
@@ -432,6 +432,3 @@ layout: layout
     &lt;/customHeaders&gt;</strong>
   &lt;/httpProtocol&gt;
 &lt;/system.webServer&gt;</pre>
-
-      
-

--- a/www/strict-dynamic.html
+++ b/www/strict-dynamic.html
@@ -11,11 +11,11 @@ date: Last Modified
 <h2>A strict-dynamic Example</h2>
 <p>Here is an example <code>Content-Security-Policy</code> that uses <code>strict-dynamic</code>:</p>
 <pre>
-script-src 'nonce-r@nd0m' 'strict-dynamic';default-src 'self';
+script-src 'nonce-rAnd0m' 'strict-dynamic';default-src 'self';
 </pre>
 <p>Now we can simply use a nonce to load our scripts:</p>
 <pre>
-&lt;script src="/script-loader.js" nonce="r@nd0m"&gt;&lt;/script&gt;
+&lt;script src="/script-loader.js" nonce="rAnd0m"&gt;&lt;/script&gt;
 </pre>
 <p>The key super power of <code>strict-dynamic</code> is that it will allow <code>/script-loader.js</code> to load additional scripts via <em>non-"parser-inserted"</em> script elements.</p>
 <p>So how do you create a <em>non-"parser-inserted"</em> script element? Here's an example:</p>
@@ -42,10 +42,10 @@ script-src 'nonce-r@nd0m' 'strict-dynamic';default-src 'self';
 	content security policy: ignoring “'unsafe-eval'” within script-src: ‘strict-dynamic’ specified
 </blockquote>
 <p>So our script can be made backwards compatable by doing something like this:</p>
-<pre>script-src 'nonce-r@nd0m' 'strict-dynamic' https: 'self';default-src 'self';</pre>
+<pre>script-src 'nonce-rAnd0m' 'strict-dynamic' https: 'self';default-src 'self';</pre>
 <p>Above we have added 'self' to allow loading of <code>/script-loader.js</code> and we have added <code>https:</code> to allow loading of <code>https://cdn.example.com/some-script-you-need.min.js</code></p>
 <p>You may notice that by adding <code>https:</code> we are allowing any domain to load a script, you could be more specific if you wanted to. In our example the following would be better:</p>
-<pre>script-src 'nonce-r@nd0m' 'strict-dynamic' cdn.example.com 'self';default-src 'self';</pre>
+<pre>script-src 'nonce-rAnd0m' 'strict-dynamic' cdn.example.com 'self';default-src 'self';</pre>
 <p>If we had an <a href="/examples/allow-inline-script/">inline script block</a> then we could consider adding <code>'unsafe-inline'</code> to the policy to allow it to load on CSP Level 1 Browsers. You'll need to balance the compexity of your policy vs the bredth of browsers that you want to support.</p>
 <p>On older browsers you may see something like this:</p>
 <blockquote>


### PR DESCRIPTION
Invalid nonce values are often ignored by browsers, causing the examples using "r@nd0m" to not work. The replacement value "rAnd0m" was taken from the nonce page, which does use a valid nonce.