### PR TITLE
Correct source list expressions ignored by 'strict-dynamic'

### DIFF
--- a/www/strict-dynamic.html
+++ b/www/strict-dynamic.html
@@ -30,9 +30,9 @@ script-src 'nonce-rAnd0m' 'strict-dynamic';default-src 'self';
 <p>Thankfully the authors of CSP Level 3 considered this, and have a clever workaround. When <code>strict-dynamic</code> is used, browsers that support it will ignore the following source list expressions:</p>
 <ul>
 	<li><code><a href="/unsafe-inline/">'unsafe-inline'</a></code></li>
-	<li><code>'unsafe-eval'</code></li>
 	<li><code>'self'</code>
-	<li><code>http:</code> or <code>https:</code> host based source lists</li>
+	<li>Host based source lists</li>
+	<li>Protocol based source lists (e.g. <code>http:</code> and <code>https:</code>)</li>
 </ul>
 <p>In fact you might see something like this in your developer tools console:</p>
 <blockquote>


### PR DESCRIPTION
### Relevant page excerpt

> When strict-dynamic is used, browsers that support it will ignore the following source list expressions:
> - [`'unsafe-inline'`](https://content-security-policy.com/unsafe-inline/)
> - `'unsafe-eval'`
> - `'self'`
> - `http:` or `https:` host based source lists

### Splitting host/protocol source entry

When I first read the final bullet point above, I was a little confused about whether host sources were ignored only when they had a protocol, and wondered about protocols that weren't HTTP/S (e.g. `wss:`). After further reading I realized that host sources are ignored and additionally protocol scheme sources were ignored. I figured splitting this into two separate bullets was more clear.

### Removal of `'unsafe-eval'`

In the [CSP3 draft specification](https://www.w3.org/TR/CSP3/#strict-dynamic-usage), 'unsafe-eval' is not present in the list of sources ignored when 'strict-dynamic' is present in the policy. Implementations by current versions of Chromium and Firefox do not ignore 'unsafe-eval' with 'strict-dynamic'.

Minimal (albeit gross) example:

```html
<html>
<head><title>strict-dynamic Test</title></head>
<body>
  <script nonce="rAnd0m">
    document.body.innerHTML += 'nonced inline code ran<br>'
    eval("document.body.innerHTML += 'nonced inline eval ran<br>'")
  </script>
  <script>
    document.body.innerHTML += 'inline code ran<br>'
    eval("document.body.innerHTML += 'inline eval ran<br>'")
  </script>
</body>
</html>
```

With this CSP:

```
Content-Security-Policy: script-src 'strict-dynamic' 'nonce-rAnd0m'
```

the body becomes:

> nonced inline code ran

The eval call and inline code without a nonce is blocked by the browser.

When the CSP includes `'unsafe-eval'`:

```
Content-Security-Policy: script-src 'strict-dynamic' 'nonce-rAnd0m' 'unsafe-eval'
```

> nonced inline code ran
> nonced inline eval ran

And as expected, adding `'unsafe-inline'` to the CSP is ignored:

```
Content-Security-Policy: script-src 'strict-dynamic' 'nonce-rAnd0m' 'unsafe-eval' 'unsafe-inline'
```

> nonced inline code ran
> nonced inline eval ran